### PR TITLE
bump truv_flutter to 1.6.0

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -5,8 +5,8 @@ PODS:
     - FlutterMacOS
   - truv_flutter (1.0.0):
     - Flutter
-    - TruvSDK (= 1.9.0)
-  - TruvSDK (1.9.0)
+    - TruvSDK (= 1.11.0)
+  - TruvSDK (1.11.0)
 
 DEPENDENCIES:
   - Flutter (from `Flutter`)
@@ -27,9 +27,9 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   Flutter: cabc95a1d2626b1b06e7179b784ebcf0c0cde467
-  path_provider_foundation: 0b743cbb62d8e47eab856f09262bb8c1ddcfe6ba
-  truv_flutter: 70533b6374006b6acbbd0e664b9f371a03d13ff3
-  TruvSDK: 5a89612ec217bc628574af3a6eb17c17ec2d3234
+  path_provider_foundation: bb55f6dbba17d0dccd6737fe6f7f34fbd0376880
+  truv_flutter: 3844e6bb33c56a2b75c7848b14c6539163ba3ea3
+  TruvSDK: 35c7604e9848de96add6402b2ccc9f2ed1080a7c
 
 PODFILE CHECKSUM: 1efa8702e3c56755e99df3bdd633b3efc1f27133
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -117,10 +117,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
+      sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.0"
+    version: "1.4.1"
   checked_yaml:
     dependency: transitive
     description:
@@ -431,26 +431,26 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
+      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.17"
+    version: "0.12.19"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
+      sha256: "9c337007e82b1889149c82ed242ed1cb24a66044e30979c44912381e9be4c48b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.11.1"
+    version: "0.13.0"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: e3641ec5d63ebf0d9b41bd43201a66e3fc79a65db5f61fc181f04cd27aab950c
+      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
       url: "https://pub.dev"
     source: hosted
-    version: "1.16.0"
+    version: "1.17.0"
   mime:
     dependency: transitive
     description:
@@ -692,10 +692,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "522f00f556e73044315fa4585ec3270f1808a4b186c936e612cab0b565ff1e00"
+      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.6"
+    version: "0.7.10"
   timing:
     dependency: transitive
     description:
@@ -708,10 +708,10 @@ packages:
     dependency: "direct main"
     description:
       name: truv_flutter
-      sha256: d668107caf560938c9dd9705e29b75320e2b40ccd2cb20a08cefae3d127db8f2
+      sha256: c3e06d5fa1184c3d05932211e154f2de635a5fb2123bfd210464c44e0a4f8662
       url: "https://pub.dev"
     source: hosted
-    version: "1.5.0"
+    version: "1.6.0-rc.1"
   typed_data:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -708,10 +708,10 @@ packages:
     dependency: "direct main"
     description:
       name: truv_flutter
-      sha256: c3e06d5fa1184c3d05932211e154f2de635a5fb2123bfd210464c44e0a4f8662
+      sha256: "7412e042c9df290b31590b5d9a0d067127b7db22bc01c7598dbc254f313b5953"
       url: "https://pub.dev"
     source: hosted
-    version: "1.6.0-rc.1"
+    version: "1.6.0"
   typed_data:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -38,7 +38,7 @@ dependencies:
   freezed: ^2.4.7
   freezed_annotation: ^2.4.1
   json_annotation: ^4.9.0
-  truv_flutter: ^1.5.0
+  truv_flutter: 1.6.0-rc.1
   # uncomment next line and remove version to use the local sdk
     # path: ../flutter-sdk
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -38,7 +38,7 @@ dependencies:
   freezed: ^2.4.7
   freezed_annotation: ^2.4.1
   json_annotation: ^4.9.0
-  truv_flutter: 1.6.0-rc.1
+  truv_flutter: 1.6.0
   # uncomment next line and remove version to use the local sdk
     # path: ../flutter-sdk
 


### PR DESCRIPTION
Bump truv_flutter → **1.6.0** (final). Follows flutter-sdk 1.6.0 release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated a third-party package to a newer fixed version, helping keep the app’s behavior consistent and up to date.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->